### PR TITLE
Fix Block table name and add psycopg2

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -14,9 +14,8 @@ class User(UserMixin, db.Model):
     token_balance = db.Column(db.Float, default=0.0)  # Баланс токенов
 
 class Block(db.Model):
-    __tablename__ = "блок"  # Explicit Cyrillic table name
     """Контентний блок (для 6 секцій сайту)"""
-    __tablename__ = 'block'  # Explicitly set to Latin to match what db.create_all() creates
+    __tablename__ = "блок"
     id = db.Column(db.Integer, primary_key=True)
     title = db.Column(db.String(128))
     content = db.Column(db.Text)

--- a/app/models.py.bak
+++ b/app/models.py.bak
@@ -15,7 +15,7 @@ class User(UserMixin, db.Model):
 
 class Block(db.Model):
     """Контентний блок (для 6 секцій сайту)"""
-    __tablename__ = 'block'  # Explicitly set to Latin to match what db.create_all() creates
+    __tablename__ = "блок"
     id = db.Column(db.Integer, primary_key=True)
     title = db.Column(db.String(128))
     content = db.Column(db.Text)

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -13,3 +13,4 @@ python-dotenv
 email_validator
 web3
 psycopg2-binary
+psycopg2

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ python-dotenv
 email_validator
 web3
 psycopg2-binary
+psycopg2


### PR DESCRIPTION
## Summary
- switch `Block` model to use Cyrillic table name
- add `psycopg2` to project requirements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'psycopg2')*

------
https://chatgpt.com/codex/tasks/task_e_6841b3a272988329a1f26f5631dee3e4